### PR TITLE
Add support for various config options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,6 @@ consul_domain: consul.
 consul_is_server: false
 consul_is_ui: false
 consul_servers: ['127.0.0.1']
-consul_bootstrap: false
 consul_log_level: "INFO"
 consul_syslog: false
 consul_rejoin_after_leave: true

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -2,7 +2,7 @@
 {% if consul_is_ui == true %}
   "ui_dir": "{{ consul_home }}/dist",
 {% endif %}
-{% if consul_bootstrap == false %}
+{% if consul_join_at_start is defined and consul_join_at_start %}
   "start_join": {{ consul_servers|to_nice_json }},
 {% endif %}
   "domain": "{{ consul_domain }}",
@@ -15,7 +15,21 @@
   "server": {{ "true" if consul_is_server else "false" }},
   "client_addr": "{{ consul_client_address }}",
   "bind_addr": "{{ consul_bind_address }}",
+{% if consul_advertise_address is defined %}
+  "advertise_addr": "{{ consul_advertise_address }}",
+{% endif %}
   "datacenter": "{{ consul_datacenter }}",
   "rejoin_after_leave": {{ "true" if consul_rejoin_after_leave else "false" }},
+{% if consul_is_server and consul_bootstrap is defined %}
   "bootstrap": {{ "true" if consul_bootstrap else "false" }}
+{% endif %}
+{% if consul_is_server and consul_bootstrap_expect is defined %}
+  "bootstrap_expect": {{ consul_bootstrap_expect }},
+{% endif %}
+{% if consul_encrypt_key is defined %}
+  "encrypt": "{{ consul_encrypt_key }}",
+{% endif %}
+{% if consul_watches is defined %}
+  "watches": {{ consul_watches|to_nice_json }}
+{% endif %}
 }


### PR DESCRIPTION
- `advertise_addr`
- `bootstrap_expect`
- `encrypt`
- `watches`

Also, more control over `start_join`: don't assume both clients and servers want to join at start if they're not bootstrapping.  (Consul devs recommend against servers joining at start since it doesn't play well with respawn.)  Join at start is now only enabled if `consul_join_at_start` is defined and truthy.
