### PR TITLE
Install nginx config only when UI needed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,4 @@ consul_node_name: "{{ ansible_default_ipv4['address'] }}"
 consul_datacenter: "default"
 consul_ui_require_auth: false
 consul_ui_auth_user_file: /etc/htpasswd/consul
+consul_enable_nginx_config: true

--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -27,6 +27,7 @@
     owner=root
     group=root
     mode=0755
+  when: consul_is_ui
   notify:
     - restart nginx  
 
@@ -38,6 +39,7 @@
     owner=root
     group=root
     mode=0755
+  when: consul_is_ui and consul_enable_nginx_config
   notify:
   - restart nginx
 


### PR DESCRIPTION
Also, provide a configuration variable to control whether the nginx configuration gets activated. You might not want it to become activated if you want to provide your own configuration, for example because you want to tweak the config or merge it with another configuration file.
