### PR TITLE
Add support for disabling remote exec

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,3 +28,4 @@ consul_datacenter: "default"
 consul_ui_require_auth: false
 consul_ui_auth_user_file: /etc/htpasswd/consul
 consul_enable_nginx_config: true
+consul_disable_remote_exec: true

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -5,6 +5,9 @@
 {% if consul_join_at_start is defined and consul_join_at_start %}
   "start_join": {{ consul_servers|to_nice_json }},
 {% endif %}
+{% if consul_disable_remote_exec is defined and consul_disable_remote_exec %}
+  "disable_remote_exec": {{ "true" if consul_disable_remote_exec else "false" }},
+{% endif %}
   "domain": "{{ consul_domain }}",
   "data_dir": "{{ consul_home }}/data",
   "log_level": "{{ consul_log_level }}",


### PR DESCRIPTION
Taking a sensible secure approach and disabling the ability to run remote exec commands as default. This introduces the new parameter `consul_disable_remote_exec` and sets the configuration option to [disable remote execution](https://www.consul.io/docs/agent/options.html#disable_remote_exec) on consul agents.
