### PR TITLE
Allow disabling installation of dnsmasq

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,4 @@ consul_ui_require_auth: false
 consul_ui_auth_user_file: /etc/htpasswd/consul
 consul_enable_nginx_config: true
 consul_disable_remote_exec: true
+consul_install_dnsmasq: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: install.yml
 - { include: install-ui.yml, when: consul_is_ui == true }
-- include: dnsmasq.yml
+- { include: dnsmasq.yml, when: consul_install_dnsmasq == true }
 - include: consulate.yml
 - include: service.yml


### PR DESCRIPTION
We already have a nameserver running on port 53 and therefore don't need/want dnsmasq to be installed. This change makes it possible to skip dnsmasq installation by setting `consul_install_dnsmasq: false`.
