### PR TITLE
Add extra acl, gce and ec2 config variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ consul_retry_join: false
 consul_retry_interval: 30s
 consul_retry_max: 0
 
+consul_retry_join_ec2: false
+consul_retry_join_gce: false
+
 consul_servers_wan: []
 consul_join_wan: false
 consul_retry_join_wan: false
@@ -232,6 +235,26 @@ consul_recursors:
   - 8.8.8.8
   - 8.8.4.4
 ```
+
+## ACL Variables
+
+You can configure Consul to use [ACL](https://www.consul.io/docs/internals/acl.html)'s.
+
+Below are some variables that you can use to set it up. See the [official documentation](https://www.consul.io/docs/agent/options.html#acl_datacenter) for their meaning.
+
+Variables available for use, not defined by default:
+```yml
+consul_acl_enforce_version_8: false
+consul_acl_datacenter: 'test'
+consul_acl_default_policy: 'allow'
+consul_acl_down_policy: 'allow'
+consul_acl_master_token: 'generated_uuid_here'
+consul_acl_token: 'generated_uuid_here'
+consul_acl_ttl: 30
+consul_atlas_acl_token: 'anonymous'
+```
+
+
 ## Cross-origin Resource Sharing
 Consul allows adding headers to the HTTP API responses, to enable [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) set the `consul_cors_support` variable to `true`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,9 @@ consul_retry_join: false
 consul_retry_interval: 30s
 consul_retry_max: 0
 
+consul_retry_join_ec2: false
+consul_retry_join_gce: false
+
 consul_servers_wan: []
 consul_join_wan: false
 consul_retry_join_wan: false

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -22,7 +22,9 @@
     {% if consul_ec2_secret_access_key is defined %}
     "secret_access_key": "{{ consul_ec2_secret_access_key }}",
     {% endif %}
+    {% if consul_ec2_region is defined %}
     "region": "{{ consul_ec2_region }}",
+    {% endif %}
     "tag_key": "{{ consul_ec2_tag_key }}",
     "tag_value": "{{ consul_ec2_tag_value }}"
   },
@@ -37,7 +39,7 @@
     "tag_value": "{{ consul_gce_tag_value }}"
   },
 {% endif %}
-{{% if consul_join_wan|default(false) %}
+{% if consul_join_wan|default(false) %}
   "start_join_wan": [{% for host in consul_servers_wan | difference(ansible_all_ipv4_addresses) %}"{{host}}"{% if not loop.last %}, {% endif %}{% endfor %}],
 {% endif %}
 {% if consul_retry_join_wan|default(false) %}

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -140,7 +140,7 @@
   {% endif %}
 {% endif %}
 {% if consul_acl_enforce_version_8 is defined %}
-  "acl_enforce_version_8": "{{ consul_acl_enforce_version_8 }}",
+  "acl_enforce_version_8": {{ "true" if consul_acl_enforce_version_8 else "false" }},
 {% endif %}
 {% if consul_acl_datacenter is defined %}
   "acl_datacenter": "{{ consul_acl_datacenter }}",

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -14,7 +14,30 @@
   "retry_interval": "{{ consul_retry_interval }}",
   "retry_max": {{ consul_retry_max }},
 {% endif %}
-{% if consul_join_wan|default(false) %}
+{% if consul_retry_join_ec2|default(false) %}
+  "retry_join_ec2": {
+    {% if consul_ec2_access_key is defined %}
+    "access_key_id": "{{ consul_ec2_access_key }}",
+    {% endif %}
+    {% if consul_ec2_secret_access_key is defined %}
+    "secret_access_key": "{{ consul_ec2_secret_access_key }}",
+    {% endif %}
+    "region": "{{ consul_ec2_region }}",
+    "tag_key": "{{ consul_ec2_tag_key }}",
+    "tag_value": "{{ consul_ec2_tag_value }}"
+  },
+{% endif %}
+{% if consul_retry_join_gce|default(false) %}
+  "retry_join_gce": {
+    {% if consul_gce_credentials_file is defined %}
+    "credentials_file": "{{ consul_gce_credentials_file }}",
+    {% endif %}
+    "project_name": "{{ consul_gce_project_name }}",
+    "zone_pattern": "{{ consul_gce_zone_pattern }}",
+    "tag_value": "{{ consul_gce_tag_value }}"
+  },
+{% endif %}
+{{% if consul_join_wan|default(false) %}
   "start_join_wan": [{% for host in consul_servers_wan | difference(ansible_all_ipv4_addresses) %}"{{host}}"{% if not loop.last %}, {% endif %}{% endfor %}],
 {% endif %}
 {% if consul_retry_join_wan|default(false) %}
@@ -113,6 +136,9 @@
   {% if consul_atlas_join is defined %}
   "atlas_join": true,
   {% endif %}
+{% endif %}
+{% if consul_acl_enforce_version_8 is defined %}
+  "acl_enforce_version_8": "{{ consul_acl_enforce_version_8 }}",
 {% endif %}
 {% if consul_acl_datacenter is defined %}
   "acl_datacenter": "{{ consul_acl_datacenter }}",


### PR DESCRIPTION
Changes:
* Add `retry_join_ec2` variables (Fixes #192)
* Add `retry_join_gce` variables
* Add `acl_enforce_version_8` variable
* update README to show existing `acl` capabilities

