### PR TITLE
Solved nginx timeout for envconsul (long-polling)

### DIFF
--- a/templates/consul-nginx.conf.j2
+++ b/templates/consul-nginx.conf.j2
@@ -23,6 +23,11 @@ server {
       auth_basic "Restricted";
       auth_basic_user_file {{ consul_ui_auth_user_file }};
       {% endif %}
+
+      proxy_connect_timeout       600;
+      proxy_send_timeout          600;
+      proxy_read_timeout          600;
+      send_timeout                600;
   }
 
 


### PR DESCRIPTION
Since nginx is used as reverse proxy, tools using consul long-polling like envconsul receives consul timeouts continuously because the nginx timeout default value.

Consul long-polling is described here:
https://www.consul.io/api/index.html#blocking-queries

Consul has a default wait time of 5 minutes, so I've increased the nginx timeout for "/" location to 10 minutes