### PR TITLE
if consul_client_address set (in consul.conf), in the upstart script do not set -client flag …

### DIFF
--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -24,7 +24,7 @@ script
 {% if consul_dynamic_bind %}
     -bind=$BIND \
 {% endif %}
-{# In case 'consul_client_address' is set, will only configure it in consul.conf file, not here #}
+{# In case 'consul_client_address' is set, will only configure it in /etc/consul.conf, not here #}
 {% if consul_client_address_bind and not consul_client_address %}
     -client=$CLIENT_BIND \
 {% endif %}

--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -24,7 +24,8 @@ script
 {% if consul_dynamic_bind %}
     -bind=$BIND \
 {% endif %}
-{% if consul_client_address_bind %}
+{# In case 'consul_client_address' is set, will only configure it in consul.conf file, not here #}
+{% if consul_client_address_bind and not consul_client_address %}
     -client=$CLIENT_BIND \
 {% endif %}
     -config-dir={{ consul_config_dir }} \


### PR DESCRIPTION
…(from unconfigurable interface 'eth0')

In particular this fixes consul (upstart) service script deployment on any hosts that *has* an `eth0` interface, which is *not* the expected interface you want consul to listen on.
It ensures that with following settings, the upstart script does not anymore set a buggy `-client=` parameter. Instead consul gets the correct client_address (here "0.0.0.0" ) from consul.conf
```
consul_dynamic_bind: false
consul_client_address_bind: true
consul_client_address: "0.0.0.0"
```

ps: this also fixes https://github.com/savagegus/ansible-consul/issues/136 (as suggested in https://github.com/savagegus/ansible-consul/issues/136#issuecomment-234810553 by @nickvanw )
