### PR TITLE
fix missing newline in consul.conf before option only_passing

### DIFF
--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -36,9 +36,9 @@
       "*": "{{ consul_dns_service_ttl }}"
     },
     "enable_truncate": {{ "true" if consul_dns_enable_truncate else "false" }},
-    {%- if (consul_udp_answer_limit is defined) %}
+{% if (consul_udp_answer_limit is defined) %}
     "udp_answer_limit": {{ consul_udp_answer_limit }},
-    {%- endif %}
+{% endif %}
     "only_passing": {{ "true" if consul_dns_only_passing else "false" }}
   },
 {% endif %}


### PR DESCRIPTION
*without* this fix, you get following broken diff (that must have been added in the last dozen of commits in master):

```
TASK [../../ansible-consul : consul config file] ********************************************************************************************
--- before: /etc/consul.conf

-    "enable_truncate": true,
-    "only_passing": false
+    "enable_truncate": true,    "only_passing": false
``