### PR TITLE
Several minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ consul_statsite_address: "127.0.0.1:8125"
 consul_statsite_prefix: "consul"
 # if you don't want to prepend runtime telemetry with the machine's hostname (consul 0.6.4 or later)
 consul_telemetry_disable_hostname: true
+# if you want Consul to send metrics to a datadog
+consul_telemetry_dogstatsd_address: "127.0.0.1:8125"
 ```
 
 ## DNS Variables

--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -7,25 +7,25 @@
     path: "{{ consul_ui_dir }}"
     state: directory
     mode: 0755
-  when: consul_version | version_compare('0.6.1', '<')
+  when: consul_version is version_compare('0.6.1', '<')
 
 - name: download consul ui
   get_url: >
     url={{consul_ui_download}}
     dest={{consul_download_folder}}
   register: consul_ui_was_downloaded
-  when: consul_version | version_compare('0.6.1', '<') and consul_archive_ui_stat.stat.exists == False
+  when: consul_version is version_compare('0.6.1', '<') and consul_archive_ui_stat.stat.exists == False
 
 - name: create ui dir
   file: path={{ consul_ui_dir }} state=directory
-  when: consul_version | version_compare('0.6.1', '<')
+  when: consul_version is version_compare('0.6.1', '<')
 
 - name: copy and unpack ui
   unarchive: >
     src={{ consul_download_folder }}/{{ consul_ui_archive }}
     dest={{ consul_ui_dir }}
     copy=no
-  when: consul_ui_was_downloaded|changed
+  when: consul_ui_was_downloaded is changed
 
 - name: set ownership
   file: >
@@ -34,7 +34,7 @@
     owner={{consul_user}}
     group={{consul_group}}
     recurse=yes
-  when: consul_ui_was_downloaded|changed
+  when: consul_ui_was_downloaded is changed
 
 - name: consul nginx config
   template: >

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -49,7 +49,7 @@
     name={{consul_user}}
     group={{consul_group}}
     system=yes
-  when: consul_group_created|changed
+  when: consul_group_created is changed
 
 - name: create consul directory
   file: >
@@ -92,7 +92,7 @@
     src={{ consul_download_folder }}/{{ consul_archive }}
     dest={{ consul_home }}/bin
     copy=no
-  when: consul_was_downloaded|changed
+  when: consul_was_downloaded is changed
 
 - name: create TLS key
   no_log: True
@@ -137,7 +137,7 @@
     owner={{consul_user}}
     group={{consul_group}}
     recurse=yes
-  when: consul_was_downloaded|changed
+  when: consul_was_downloaded is changed
 
 - name: copy consul upstart script
   template: >

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -1,6 +1,6 @@
 {
 {% if consul_is_ui == true %}
-  {% if consul_version | version_compare('0.6.1', '<') %}
+  {% if consul_version is version_compare('0.6.1', '<') %}
     "ui_dir": "{{ consul_ui_dir }}",
   {% else %}
     "ui": true,

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -144,11 +144,14 @@
 {% if consul_statsite_prefix is defined %}
   "statsite_prefix": "{{ consul_statsite_prefix }}",
 {% endif %}
-{% if consul_telemetry_disable_hostname is defined %}
   "telemetry": {
+{% if consul_telemetry_disable_hostname is defined %}
     "disable_hostname": {{ "true" if consul_telemetry_disable_hostname else "false" }}
-  },
 {% endif %}
+{% if consul_telemetry_dogstatsd_addr is defined %}
+    "dogstatsd_addr": "{{ consul_telemetry_dogstatsd_address }}"
+{% endif %}
+  },
 {% if consul_cors_support is defined %}
   "http_api_response_headers": {
         "Access-Control-Allow-Origin": "*"

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -65,7 +65,7 @@
 {% if consul_advertise_address is defined %}
   "advertise_addr": "{{ consul_advertise_address }}",
 {% endif %}
-{% if consul_advertise_address_wan|default(false) %}
+{% if consul_advertise_address_wan|default(false) and consul_advertise_address_wan != consul_advertise_address %}
   "advertise_addr_wan": "{{ consul_advertise_address_wan }}",
 {% endif %}
   "datacenter": "{{ consul_datacenter }}",


### PR DESCRIPTION
This fork has the following minor fixes:

* Ansible deprecation warning fix: Use `is` instead of filters for tests
* Omit `advertise_addr_wan` if same as `advertise_addr`: Specifying the same address for both results in a binding error
* Add `consul_telemetry_dogstatsd_addr` setting to send metrics to Datadog agent